### PR TITLE
fix negative rate issue for states that lose reported cases

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -102,7 +102,7 @@
               <div class="buttons-container">
                 <button class="button-change-chart-transform selected" data-type="">none</button>
                 <button class="button-change-chart-transform" data-type="population">per 100k people</button>
-                <button class="button-change-chart-transform" data-type="delta">daily increase</button>
+                <button class="button-change-chart-transform" data-type="delta">new in past <input id="new-in-past-days-input" type="text" value="3" style="width: 25px"/> days</button>
                 <button class="button-change-chart-transform" data-type="doubling">days to double</button>
                 <button class="button-change-chart-transform" data-type="newVsExisting">new vs existing</button>
               </div>


### PR DESCRIPTION
- smooth sliding window for "daily increase" transform
- add input for the number of days of sliding window used for this
- add to params pulled form & saved to url
- fix edge case where daily increase goes negative when reported cases inexplicably goes down (must be reporting error)

https://github.com/octopicorn/covid19-charts/issues/44